### PR TITLE
Bump stable to 1.0.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <angular.version>1.0.5</angular.version>
+        <angular.version>1.0.6</angular.version>
         <angular.sourceUrl>http://code.angularjs.org/${angular.version}</angular.sourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${angular.version}</destDir>
     </properties>


### PR DESCRIPTION
Would you mind releasing this for me?

Also, do you mind creating another branch called unstable to make it easier to keep the unstable branches up to date? You could also rename 'master' to 'stable'. See my fork if you want to see how it looks in practice.

I already have the unstable commit ready to go in my unstable branch:
https://github.com/nbauernfeind/webjars-angularjs/tree/unstable
