### PR TITLE
Upgrade AngularJS to 1.2.0-rc.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>angularjs</artifactId>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>1.2.0-rc.2</version>
     <name>AngularJS</name>
     <description>WebJar for AngularJS</description>
     <url>http://webjars.org</url>
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <angular.version>1.0.8</angular.version>
+        <angular.version>1.2.0-rc.2</angular.version>
         <angular.sourceUrl>http://code.angularjs.org/${angular.version}</angular.sourceUrl>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${angular.version}</destDir>
     </properties>


### PR DESCRIPTION
Angular seem to have changed their version naming schema from rc1 to rc2.. 

Not sure if you want to follow angularjs strictly and use their new version naming:
1.2.0-rc.2

Or stick to the old version naming schema used by webjars in rc1
1.2.0rc2
