### PR TITLE
fixed missing angular modules in requirejs config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,10 @@
                 "paths": {
                     "angular": "angular",
                     "angular-animate": "angular-animate",
+                    "angular-aria": "angular-aria",
                     "angular-cookies": "angular-cookies",
                     "angular-loader": "angular-loader",
+                    "angular-messages": "angular-messages",
                     "angular-mocks": "angular-mocks",
                     "angular-resource": "angular-resource",
                     "angular-route": "angular-route",
@@ -194,8 +196,10 @@
                 "shim": {
                     "angular": {"exports" : "angular"},
                     "angular-animate": ["angular"],
+                    "angular-aria": ["angular"],
                     "angular-cookies": ["angular"],
                     "angular-loader": ["angular"],
+                    "angular-messages": ["angular"],
                     "angular-mocks": ["angular"],
                     "angular-resource": ["angular"],
                     "angular-route": ["angular"],

--- a/src/main/resources/webjars-requirejs.js
+++ b/src/main/resources/webjars-requirejs.js
@@ -1,7 +1,9 @@
 var webjarsAngularjsChildren = [
     'angular-animate',
+    'angular-aria',
     'angular-cookies',
     'angular-loader',
+    'angular-messages',
     'angular-mocks',
     'angular-resource',
     'angular-route',


### PR DESCRIPTION
Some new angular modules (aria, messages) are missing in the requirejs config. This pull request fixes the config. The tags (angularjs-1.3.3 / 1.3.4) must probably be adjusted to include this fix. I am not exactly sure how to deal with this issue. 

regards
Andreas
