### PR TITLE
Bunmp version to 1.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>angularjs</artifactId>
-    <version>1.7.10-SNAPSHOT</version>
+    <version>1.8.0-SNAPSHOT</version>
     <name>AngularJS</name>
     <description>WebJar for AngularJS</description>
     <url>http://webjars.org</url>


### PR DESCRIPTION
AngularJS 1.8.0 contains a fix for CVE-2020-11022.